### PR TITLE
exposing SR tables through NodeManager

### DIFF
--- a/JSONDB/JSONDB.cpp
+++ b/JSONDB/JSONDB.cpp
@@ -277,6 +277,22 @@ JsonBox::Object JSONDB::query(JsonBox::Object request, unsigned retries)
 			}
 			std::string msisdn = jit->second.getString();
 
+			jit = fields.find("ipaddr");
+			if (jit == fields.end()) {
+				response["code"] = JsonBox::Value(406);
+				response["data"] = JsonBox::Value("missing ipaddr");
+				return response;
+			}
+			std::string ipaddr = jit->second.getString();
+
+			jit = fields.find("port");
+			if (jit == fields.end()) {
+				response["code"] = JsonBox::Value(406);
+				response["data"] = JsonBox::Value("missing port");
+				return response;
+			}
+			std::string port = jit->second.getString();
+
 			jit = fields.find("ki");
 			if (jit == fields.end()) {
 				response["code"] = JsonBox::Value(406);
@@ -289,8 +305,8 @@ JsonBox::Object JSONDB::query(JsonBox::Object request, unsigned retries)
 			JsonBox::Object responseSIP;
 			JsonBox::Object responseDIAL;
 
-			queryTMP << "insert into sip_buddies (username, name, callerid, ki, host, allow, ipaddr)";
-			queryTMP << " values (\"" << imsi << "\",\"" << name << "\",\"" << msisdn << "\",\"" << ki << "\",\"dynamic\",\"gsm\",\"127.0.0.1\")";
+			queryTMP << "insert into sip_buddies (username, name, callerid, ki, host, allow, ipaddr, port)";
+			queryTMP << " values (\"" << imsi << "\",\"" << name << "\",\"" << msisdn << "\",\"" << ki << "\",\"dynamic\",\"gsm\",\"" << ipaddr << "\",\"" << port << "\" )";
 			responseSIP = execOnly(queryTMP.str());
 
 			queryTMP.str("");
@@ -343,11 +359,26 @@ JsonBox::Object JSONDB::query(JsonBox::Object request, unsigned retries)
 			}
 			std::string msisdn = jit->second.getString();
 
+			jit = fields.find("ipaddr");
+			if (jit == fields.end()) {
+				response["code"] = JsonBox::Value(406);
+				response["data"] = JsonBox::Value("missing ipaddr");
+				return response;
+			}
+			std::string ipaddr = jit->second.getString();
+
+			jit = fields.find("port");
+			if (jit == fields.end()) {
+				response["code"] = JsonBox::Value(406);
+				response["data"] = JsonBox::Value("missing port");
+				return response;
+			}
+			std::string port = jit->second.getString();
 			std::stringstream queryTMP;
 			JsonBox::Object responseSIP;
 			JsonBox::Object responseDIAL;
 
-			queryTMP << "update sip_buddies set name=\"" << name << "\", callerid=\"" << msisdn << "\" where username=\"" << imsi << "\"";
+			queryTMP << "update sip_buddies set name=\"" << name << "\", callerid=\"" << msisdn << "\", ipaddr=\"" << ipaddr << "\", port=\"" << port << "\" where username=\"" << imsi << "\"";
 			responseSIP = execOnly(queryTMP.str());
 
 			queryTMP.str("");

--- a/JSONDB/JSONDB.h
+++ b/JSONDB/JSONDB.h
@@ -37,6 +37,7 @@ class JSONDB {
 
 	sqlite3* mDB;
 	std::string generateWhereClause(JsonBox::Object request);
+	std::string generateSelectFields(JsonBox::Object request);
 	std::string implode(std::string delimiter, std::vector<std::string> pieces);
 	JsonBox::Object read(std::string query, unsigned retries = 5);
 	JsonBox::Object execOnly(std::string query, unsigned retries = 5);


### PR DESCRIPTION
- Adding the ability to specify `match` field for filtering on `command: 'subscribers'`. This is needed for selecting individual subscribers
- Adding `fields` filtering for selection on reading from tables rather than returning the entire table row. 
