### PR TITLE
JSONDB fails to connect to sqlite3

### DIFF
--- a/JSONDB/JSONDB.cpp
+++ b/JSONDB/JSONDB.cpp
@@ -241,10 +241,16 @@ JsonBox::Object JSONDB::query(JsonBox::Object request, unsigned retries)
 	}
 
 	// connect to database
-	if (!connect(dbPath)) {
-		response["code"] = JsonBox::Value(500);
-		response["data"] = JsonBox::Value("db connect failed");
-		return response;
+        int retry_count = 0;
+	while(!connect(dbPath)) {
+                usleep(100); // sleep 0.1 second
+                retry_count++;
+
+                if (retry_count > MAX_DB_CONNECT_ATTEMPTS) {
+                        response["code"] = JsonBox::Value(503);
+                        response["data"] = JsonBox::Value("db connect failed");
+                        return response;
+                }
 	}
 
 	// abstract sip_buddies and dialdata_tables into a single logical endpoint

--- a/JSONDB/JSONDB.h
+++ b/JSONDB/JSONDB.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 
+#define MAX_DB_CONNECT_ATTEMPTS 10
 
 class JSONDB {
 


### PR DESCRIPTION
WIP

Here is what is happening. We are connect with multiple ZMQ sockets to NodeManager with each instance of `openbts.components.SIPAuthServe()` and it seems that they are competing for the connection to the sqlitedb. This was coming up in phone_tests on client

This adds a 10x retry spaced 0.1 seconds apart in the attempt that the connection fails. I think this is what we were doing pre-openbts 5.0

 I am tempted to move the `connect()` to https://github.com/endaga/subscriberRegistry/blob/master/apps/sipauthserve.cpp#L64 so that we have one sqlite3 connection per instance of `sipauthserve` but need to better understand the repercussions of that
